### PR TITLE
Use system time for joint_state_broadcaster

### DIFF
--- a/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
+++ b/joint_state_broadcaster/include/joint_state_broadcaster/joint_state_broadcaster.hpp
@@ -27,6 +27,7 @@
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "realtime_tools/realtime_publisher.h"
 #include "sensor_msgs/msg/joint_state.hpp"
+#include "rclcpp/clock.hpp"
 
 namespace joint_state_broadcaster
 {
@@ -111,6 +112,7 @@ protected:
     dynamic_joint_state_publisher_;
   std::shared_ptr<realtime_tools::RealtimePublisher<control_msgs::msg::DynamicJointState>>
     realtime_dynamic_joint_state_publisher_;
+  rclcpp::Clock clock_ = rclcpp::Clock();
 };
 
 }  // namespace joint_state_broadcaster

--- a/joint_state_broadcaster/src/joint_state_broadcaster.cpp
+++ b/joint_state_broadcaster/src/joint_state_broadcaster.cpp
@@ -336,7 +336,7 @@ double get_value(
 }
 
 controller_interface::return_type JointStateBroadcaster::update(
-  const rclcpp::Time & time, const rclcpp::Duration & /*period*/)
+  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
 {
   for (const auto & state_interface : state_interfaces_)
   {
@@ -355,7 +355,7 @@ controller_interface::return_type JointStateBroadcaster::update(
   if (realtime_joint_state_publisher_ && realtime_joint_state_publisher_->trylock())
   {
     auto & joint_state_msg = realtime_joint_state_publisher_->msg_;
-    joint_state_msg.header.stamp = time;
+    joint_state_msg.header.stamp = clock_.now();
 
     // update joint state message and dynamic joint state message
     for (size_t i = 0; i < joint_names_.size(); ++i)
@@ -372,7 +372,7 @@ controller_interface::return_type JointStateBroadcaster::update(
   if (realtime_dynamic_joint_state_publisher_ && realtime_dynamic_joint_state_publisher_->trylock())
   {
     auto & dynamic_joint_state_msg = realtime_dynamic_joint_state_publisher_->msg_;
-    dynamic_joint_state_msg.header.stamp = time;
+    dynamic_joint_state_msg.header.stamp = clock_.now();
     for (size_t joint_index = 0; joint_index < dynamic_joint_state_msg.joint_names.size();
          ++joint_index)
     {


### PR DESCRIPTION
In the gazebo ros2 control that we use, [gazebo time is used](https://github.com/ros-controls/gazebo_ros2_control/blob/0dbce66334b1b1e49dec923527e03897d8ffc74d/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp#L371) with no option to use system time. The controllers, namely joint_state_broadcaster will use the same time as the controller manager.

While it does make sense to use the sim time, all our system still uses system time for gazebo simulation. This PR is to force joint_state_broadcaster to use system time.

We should revert this once our other components use sim time