### PR TITLE
Create-reset-odom-service

### DIFF
--- a/tricycle_controller/CMakeLists.txt
+++ b/tricycle_controller/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(controller_interface REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
@@ -42,6 +43,7 @@ ament_target_dependencies(
   geometry_msgs
   hardware_interface
   nav_msgs
+  std_msgs
   pluginlib
   rclcpp
   rclcpp_lifecycle

--- a/tricycle_controller/include/tricycle_controller/odometry.hpp
+++ b/tricycle_controller/include/tricycle_controller/odometry.hpp
@@ -32,7 +32,6 @@ class Odometry
 public:
   explicit Odometry(size_t velocity_rolling_window_size = 10);
 
-  void init(const rclcpp::Time & time);
   bool updateFromVelocity(double left_vel, double right_vel, const rclcpp::Time & time);
   void updateOpenLoop(double linear, double angular, const rclcpp::Time & time);
   void resetOdometry();

--- a/tricycle_controller/include/tricycle_controller/tricycle_controller.hpp
+++ b/tricycle_controller/include/tricycle_controller/tricycle_controller.hpp
@@ -33,6 +33,7 @@
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "hardware_interface/handle.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "std_srvs/srv/empty.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/state.hpp"
 #include "realtime_tools/realtime_box.h"
@@ -157,6 +158,8 @@ protected:
 
   realtime_tools::RealtimeBox<std::shared_ptr<TwistStamped>> received_velocity_msg_ptr_{nullptr};
 
+  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr reset_odom_service_;
+
   std::queue<TwistStamped> previous_commands_;  // last two commands
 
   // speed limiters
@@ -173,6 +176,10 @@ protected:
   bool is_halted = false;
   bool use_stamped_vel_ = true;
 
+  void reset_odometry(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<std_srvs::srv::Empty::Request> req,
+    std::shared_ptr<std_srvs::srv::Empty::Response> res);
   bool reset();
   void halt();
 };

--- a/tricycle_controller/package.xml
+++ b/tricycle_controller/package.xml
@@ -13,6 +13,7 @@
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>nav_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>rcpputils</depend>

--- a/tricycle_controller/src/odometry.cpp
+++ b/tricycle_controller/src/odometry.cpp
@@ -36,13 +36,6 @@ Odometry::Odometry(size_t velocity_rolling_window_size)
 {
 }
 
-void Odometry::init(const rclcpp::Time & time)
-{
-  // Reset accumulators and timestamp:
-  resetAccumulators();
-  timestamp_ = time;
-}
-
 bool Odometry::updateFromVelocity(double Ws, double alpha, const rclcpp::Time & time)
 {
   // using naming convention in http://users.isr.ist.utl.pt/~mir/cadeiras/robmovel/Kinematics.pdf
@@ -82,6 +75,7 @@ void Odometry::resetOdometry()
   x_ = 0.0;
   y_ = 0.0;
   heading_ = 0.0;
+  resetAccumulators();
 }
 
 void Odometry::setWheelParams(double wheelbase, double wheel_radius)


### PR DESCRIPTION
After working on this I realized that it's not useful for us because our last TF and odom are published by robot_localization.
But anyway it's a cool thing to add if we were using the controller's odometry for publishing TF, so we can add it.

FYI: to reset odometry with robot_localization run
`ros2 service call /amr2/set_pose robot_localization/srv/SetPose`