### PR TITLE
Extend Tricycle Controller with “Safe” Velocity Clipping

### DIFF
--- a/tricycle_controller/CMakeLists.txt
+++ b/tricycle_controller/CMakeLists.txt
@@ -27,7 +27,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   std_srvs
   tf2
   tf2_msgs
-  amr_hardware
 )
 
 find_package(ament_cmake REQUIRED)

--- a/tricycle_controller/CMakeLists.txt
+++ b/tricycle_controller/CMakeLists.txt
@@ -27,6 +27,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   std_srvs
   tf2
   tf2_msgs
+  amr_hardware
 )
 
 find_package(ament_cmake REQUIRED)

--- a/tricycle_controller/include/tricycle_controller/tricycle_controller.hpp
+++ b/tricycle_controller/include/tricycle_controller/tricycle_controller.hpp
@@ -38,6 +38,7 @@
 #include "std_srvs/srv/empty.hpp"
 #include "std_srvs/srv/set_bool.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
+#include "amr_hardware_interface/constants.hpp"
 
 #include "tricycle_controller/odometry.hpp"
 #include "tricycle_controller/steering_limiter.hpp"
@@ -155,6 +156,7 @@ protected:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<std_srvs::srv::SetBool::Request> req,
     std::shared_ptr<std_srvs::srv::SetBool::Response> res);
+  void clip_wheel_speed_and_steering_angle(double & wheel_speed, double & steering_angle);
   bool reset();
   void halt();
 };

--- a/tricycle_controller/include/tricycle_controller/tricycle_controller.hpp
+++ b/tricycle_controller/include/tricycle_controller/tricycle_controller.hpp
@@ -38,7 +38,6 @@
 #include "std_srvs/srv/empty.hpp"
 #include "std_srvs/srv/set_bool.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
-#include "amr_hardware_interface/constants.hpp"
 
 #include "tricycle_controller/odometry.hpp"
 #include "tricycle_controller/steering_limiter.hpp"
@@ -157,6 +156,8 @@ protected:
     const std::shared_ptr<std_srvs::srv::SetBool::Request> req,
     std::shared_ptr<std_srvs::srv::SetBool::Response> res);
   void clip_wheel_speed_and_steering_angle(double & wheel_speed, double & steering_angle);
+   void clip_speed_for_angle(double & wheel_speed, double steering_angle);
+  void clip_angle_for_speed(double & steering_angle, double wheel_speed);
   bool reset();
   void halt();
 };

--- a/tricycle_controller/src/tricycle_controller.cpp
+++ b/tricycle_controller/src/tricycle_controller.cpp
@@ -86,50 +86,69 @@ InterfaceConfiguration TricycleController::state_interface_configuration() const
   return state_interfaces_config;
 }
 
-void clip_speed_for_angle(double & wheel_speed, double steering_angle)
+void TricycleController::clip_speed_for_angle(
+  double & wheel_speed,
+  double steering_angle)
 {
-  const auto & limits_map = LIMITS.at(NORMAL);
-  const auto & speed_limits = limits_map.at("speed_limits");
-  const auto & angle_limits = limits_map.at("angle_limits");
+  // remember original
+  double original_ws = wheel_speed;
 
-  double speed_scale = 0.1;
+  // your existing logic (using params_.clipping_speed_limits etc.)
+  const auto & speed_limits = params_.clipping.speed_limits;
+  const auto & angle_limits = params_.clipping.angle_limits;
+  double speed_scale         = 0.1;
   double speed_offset_factor = 0.98;
+  double min_speed = 0.0, max_speed = 0.0;
 
-  double min_speed = 0.0;
-  double max_speed = 0.0;
-
-  for (std::size_t i = 0; i < angle_limits.size(); ++i) {
+  for (size_t i = 0; i < angle_limits.size(); ++i) {
     if (angle_limits[i] >= std::abs(steering_angle)) {
       if (speed_limits[i] < min_speed) {
         min_speed = speed_limits[i] + speed_scale;
       }
-      if (i + 1 < speed_limits.size() && speed_limits[i + 1] > max_speed) {
-        max_speed = speed_limits[i + 1] * speed_offset_factor - speed_scale;
+      if (i+1 < speed_limits.size() && speed_limits[i+1] > max_speed) {
+        max_speed = speed_limits[i+1]*speed_offset_factor - speed_scale;
       }
     }
   }
-
   wheel_speed = std::clamp(wheel_speed, min_speed, max_speed);
+
+  // log if we actually clipped
+  if (wheel_speed != original_ws) {
+    RCLCPP_INFO(
+      get_node()->get_logger(),
+      "Clipped wheel speed from %.3f to %.3f for steering angle %.3f",
+      original_ws, wheel_speed, steering_angle
+    );
+  }
 }
 
-void clip_angle_for_speed(double & steering_angle, double wheel_speed)
+void TricycleController::clip_angle_for_speed(
+  double & steering_angle,
+  double   wheel_speed)
 {
-  const auto & limits_map = LIMITS.at(NORMAL);
-  const auto & speed_limits = limits_map.at("speed_limits");
-  const auto & angle_limits = limits_map.at("angle_limits");
+  // remember original
+  double original_alpha = steering_angle;
 
-  auto loc = std::lower_bound(speed_limits.begin(), speed_limits.end(), std::abs(wheel_speed));
-  int index = static_cast<int>(loc - speed_limits.begin()) - 1;
+  // existing logic
+  const auto & speed_limits = params_.clipping.speed_limits;
+  const auto & angle_limits = params_.clipping.angle_limits;
+  auto loc = std::lower_bound(speed_limits.begin(),
+                              speed_limits.end(),
+                              std::abs(wheel_speed));
+  int idx = int(loc - speed_limits.begin()) - 1;
+  idx = std::clamp(idx, 0, int(angle_limits.size()) - 1);
 
-  if (index < 0) {
-    index = 0;
-  }
-  if (index >= static_cast<int>(angle_limits.size())) {
-    index = static_cast<int>(angle_limits.size() - 1);
-  }
-
-  double angle_limit = angle_limits[index];
+  double angle_limit = angle_limits[idx];
   steering_angle = std::clamp(steering_angle, -angle_limit, angle_limit);
+
+  // log if we actually clipped
+  if (steering_angle != original_alpha) {
+    RCLCPP_INFO(
+      get_node()->get_logger(),
+      "Clipped steering angle from %.3f to %.3f for wheel speed %.3f",
+      original_alpha, steering_angle, wheel_speed
+    );
+  }
 }
 
 void TricycleController::clip_wheel_speed_and_steering_angle(
@@ -138,7 +157,6 @@ void TricycleController::clip_wheel_speed_and_steering_angle(
   clip_speed_for_angle(wheel_speed, steering_angle);
   clip_angle_for_speed(steering_angle, wheel_speed);
 }
-
 
 controller_interface::return_type TricycleController::update(
   const rclcpp::Time & time, const rclcpp::Duration & period)
@@ -220,7 +238,7 @@ controller_interface::return_type TricycleController::update(
   auto [alpha_write, Ws_write] = twist_to_ackermann(linear_command, angular_command);
 
   // Clip
-  if (params_.use_normal_clipping && (std::abs(Ws_write) > 1e-6 || std::abs(alpha_write) > 1e-6))
+  if (params_.use_clipping && (std::abs(Ws_write) > 1e-6 || std::abs(alpha_write) > 1e-6))
   {
     clip_wheel_speed_and_steering_angle(Ws_write, alpha_write);
   }

--- a/tricycle_controller/src/tricycle_controller.cpp
+++ b/tricycle_controller/src/tricycle_controller.cpp
@@ -90,10 +90,6 @@ void TricycleController::clip_speed_for_angle(
   double & wheel_speed,
   double steering_angle)
 {
-  // remember original
-  double original_ws = wheel_speed;
-
-  // your existing logic (using params_.clipping_speed_limits etc.)
   const auto & speed_limits = params_.clipping.speed_limits;
   const auto & angle_limits = params_.clipping.angle_limits;
   double speed_scale         = 0.1;
@@ -111,25 +107,12 @@ void TricycleController::clip_speed_for_angle(
     }
   }
   wheel_speed = std::clamp(wheel_speed, min_speed, max_speed);
-
-  // log if we actually clipped
-  if (wheel_speed != original_ws) {
-    RCLCPP_INFO(
-      get_node()->get_logger(),
-      "Clipped wheel speed from %.3f to %.3f for steering angle %.3f",
-      original_ws, wheel_speed, steering_angle
-    );
-  }
 }
 
 void TricycleController::clip_angle_for_speed(
   double & steering_angle,
   double   wheel_speed)
 {
-  // remember original
-  double original_alpha = steering_angle;
-
-  // existing logic
   const auto & speed_limits = params_.clipping.speed_limits;
   const auto & angle_limits = params_.clipping.angle_limits;
   auto loc = std::lower_bound(speed_limits.begin(),
@@ -140,15 +123,6 @@ void TricycleController::clip_angle_for_speed(
 
   double angle_limit = angle_limits[idx];
   steering_angle = std::clamp(steering_angle, -angle_limit, angle_limit);
-
-  // log if we actually clipped
-  if (steering_angle != original_alpha) {
-    RCLCPP_INFO(
-      get_node()->get_logger(),
-      "Clipped steering angle from %.3f to %.3f for wheel speed %.3f",
-      original_alpha, steering_angle, wheel_speed
-    );
-  }
 }
 
 void TricycleController::clip_wheel_speed_and_steering_angle(

--- a/tricycle_controller/src/tricycle_controller_parameter.yaml
+++ b/tricycle_controller/src/tricycle_controller_parameter.yaml
@@ -239,9 +239,21 @@ tricycle_controller:
     default_value: 20.0, # seconds
     description: "Time threshold after which to use stationary steering limits when speed is below low_speed_threshold",
   }
-  use_normal_clipping: {
+  use_clipping: {
     type: bool,
     default_value: false,
     description: "If true, applies normal clipping to wheel speed and steering angle."
   }
+  # only used when use_clipping == true
+  clipping:
+    speed_limits: {
+      type: double_array,
+      default_value: [ -4.0, -2.4, -1.12, 2.4, 4.0, 8.0, 12.0 ],
+      description: "Speed breakpoints for clipping."
+    }
+    angle_limits: {
+      type: double_array,
+      default_value: [ 1.5708, 1.5708, 1.5708, 1.5708, 0.567232, 0.1 ],
+      description: "Steering‑angle limits corresponding to the speed breakpoints."
+    }
 

--- a/tricycle_controller/src/tricycle_controller_parameter.yaml
+++ b/tricycle_controller/src/tricycle_controller_parameter.yaml
@@ -239,3 +239,9 @@ tricycle_controller:
     default_value: 20.0, # seconds
     description: "Time threshold after which to use stationary steering limits when speed is below low_speed_threshold",
   }
+  use_normal_clipping: {
+    type: bool,
+    default_value: false,
+    description: "If true, applies normal clipping to wheel speed and steering angle."
+  }
+


### PR DESCRIPTION
What’s Changed:

New Params
-- use_clipping (bool): enable/disable wheel‑level clipping
-- clipping_speed_limits & clipping_angle_limits (arrays): define Ws vs. steering‑angle envelopes

Clipping Logic
-- Two private methods clamp wheel angular speed and steering angle against the limits

Zero Impact by Default

Clipping disabled unless use_clipping is true

All original kinematics and limiters remain intact