### PR TITLE
Limit turning rate at high speeds

### DIFF
--- a/tricycle_controller/src/tricycle_controller.cpp
+++ b/tricycle_controller/src/tricycle_controller.cpp
@@ -211,6 +211,17 @@ controller_interface::return_type TricycleController::update(
   // Compute wheel velocity and angle
   auto [alpha_write, Ws_write] = twist_to_ackermann(linear_command, angular_command);
 
+  // When steering angle slightly exceeds max turning rate at high speed, it should be capped to this rate
+  if (Ws_write >= 8.0 &&
+      std::abs(alpha_write) > params_.steering_angle_limit_high_speed  &&
+      std::abs(alpha_write) < params_.steering_angle_limit_high_speed + params_.high_speed_steering_limit_threshold)
+  {
+    alpha_write = std::clamp(
+      alpha_write,
+      -params_.steering_angle_limit_high_speed ,
+       params_.steering_angle_limit_high_speed );
+  }
+
   // Clip
   if (params_.use_clipping && (std::abs(Ws_write) > 1e-6 || std::abs(alpha_write) > 1e-6))
   {

--- a/tricycle_controller/src/tricycle_controller.cpp
+++ b/tricycle_controller/src/tricycle_controller.cpp
@@ -212,7 +212,7 @@ controller_interface::return_type TricycleController::update(
   auto [alpha_write, Ws_write] = twist_to_ackermann(linear_command, angular_command);
 
   // When steering angle slightly exceeds max turning rate at high speed, it should be capped to this rate
-  if (Ws_write >= 8.0 &&
+  if (Ws_write >= params_.high_speed_threshold &&
       std::abs(alpha_write) > params_.steering_angle_limit_high_speed  &&
       std::abs(alpha_write) < params_.steering_angle_limit_high_speed + params_.high_speed_steering_limit_threshold)
   {

--- a/tricycle_controller/src/tricycle_controller_parameter.yaml
+++ b/tricycle_controller/src/tricycle_controller_parameter.yaml
@@ -256,3 +256,13 @@ tricycle_controller:
       default_value: [ 1.5708, 1.5708, 1.5708, 1.5708, 0.567232, 0.1 ],
       description: "Steering‑angle limits corresponding to the speed breakpoints."
     }
+  high_speed_steering_limit_threshold: {
+    type: double,
+    default_value: 0.0349,
+    description: "Soft‑clamp range past the hard steering limit.",
+  }
+  steering_angle_limit_high_speed: {
+    type: double,
+    default_value: 0.0645772,
+    description: "Hard steering‐angle limit (rad) used at high speed.",
+  }

--- a/tricycle_controller/src/tricycle_controller_parameter.yaml
+++ b/tricycle_controller/src/tricycle_controller_parameter.yaml
@@ -256,6 +256,11 @@ tricycle_controller:
       default_value: [ 1.5708, 1.5708, 1.5708, 1.5708, 0.567232, 0.1 ],
       description: "Steering‑angle limits corresponding to the speed breakpoints."
     }
+  high_speed_threshold: {
+    type: double,
+    default_value: 8.0,
+    description: "Speed threshold (rad/s) above which high-speed steering limits apply."
+  }
   high_speed_steering_limit_threshold: {
     type: double,
     default_value: 0.0349,


### PR DESCRIPTION
To drive faster at higher speeds, when **alpha_write** slightly exceeds **steering_angle_limit_high_speed**, it is capped to this rate. 

**high_speed_steering_limit_threshold** and **steering_angle_limit_high_speed** are added to **tricycle_controller_parameters.yaml** to make them tunable